### PR TITLE
Forge 31.2.0 fixes (#1605)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ mod_version=10.0.0
 
 minecraft_version=1.15.2
 minecraft_version_toml=15
-forge_version=31.1.88
+forge_version=31.2.0
 forge_version_toml=31
 forge_group=net.minecraftforge
 mappings_version=0-1.15.2

--- a/src/main/java/biomesoplenty/api/sound/BOPSounds.java
+++ b/src/main/java/biomesoplenty/api/sound/BOPSounds.java
@@ -11,5 +11,5 @@ import net.minecraft.util.SoundEvent;
 
 public class BOPSounds
 {
-    public static SoundEvent music_disc_wanderer;
+	public static SoundEvent music_disc_wanderer;
 }

--- a/src/main/java/biomesoplenty/common/item/MusicDiscItemBOP.java
+++ b/src/main/java/biomesoplenty/common/item/MusicDiscItemBOP.java
@@ -8,15 +8,27 @@
 package biomesoplenty.common.item;
 
 import biomesoplenty.common.util.inventory.ItemGroupBOP;
+import biomesoplenty.core.BiomesOPlenty;
 import net.minecraft.item.Item;
 import net.minecraft.item.MusicDiscItem;
 import net.minecraft.item.Rarity;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.ForgeRegistries;
 
 public class MusicDiscItemBOP extends MusicDiscItem
 {
-    public MusicDiscItemBOP(SoundEvent record)
+	//Provide a resource location and the correct registry to retrieve a SoundEvent supplier
+    public static RegistryObject<SoundEvent> soundProvider(String soundName) {
+        return RegistryObject.of(
+            new ResourceLocation(BiomesOPlenty.MOD_ID, soundName),
+            ForgeRegistries.SOUND_EVENTS
+        );
+    };
+	
+    public MusicDiscItemBOP(String record)
     {
-        super(0, record, new Item.Properties().tab(ItemGroupBOP.instance).rarity(Rarity.RARE).stacksTo(1));
+        super(0, soundProvider(record), new Item.Properties().tab(ItemGroupBOP.instance).rarity(Rarity.RARE).stacksTo(1));
     }
 }

--- a/src/main/java/biomesoplenty/init/ModItems.java
+++ b/src/main/java/biomesoplenty/init/ModItems.java
@@ -7,7 +7,6 @@
  ******************************************************************************/
 package biomesoplenty.init;
 
-import biomesoplenty.api.sound.BOPSounds;
 import biomesoplenty.common.entity.item.BoatEntityBOP;
 import biomesoplenty.common.item.BoatItemBOP;
 import biomesoplenty.common.item.MusicDiscItemBOP;
@@ -29,7 +28,7 @@ public class ModItems
         mud_ball = registerItem(new Item(new Item.Properties().tab(ItemGroupBOP.instance)), "mud_ball");
         mud_brick = registerItem(new Item(new Item.Properties().tab(ItemGroupBOP.instance)), "mud_brick");
         
-        music_disc_wanderer = registerItem(new MusicDiscItemBOP(BOPSounds.music_disc_wanderer), "music_disc_wanderer");
+        music_disc_wanderer = registerItem(new MusicDiscItemBOP("music_disc.wanderer"), "music_disc_wanderer");
 
         fir_boat = registerItem(new BoatItemBOP(BoatEntityBOP.Type.FIR, (new Item.Properties()).stacksTo(1).tab(ItemGroupBOP.instance)), "fir_boat");
         redwood_boat = registerItem(new BoatItemBOP(BoatEntityBOP.Type.REDWOOD, (new Item.Properties()).stacksTo(1).tab(ItemGroupBOP.instance)), "redwood_boat");

--- a/src/main/java/biomesoplenty/init/ModSounds.java
+++ b/src/main/java/biomesoplenty/init/ModSounds.java
@@ -17,6 +17,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 import static biomesoplenty.api.sound.BOPSounds.music_disc_wanderer;
 
+
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ModSounds
 {


### PR DESCRIPTION
* Changed environment for testing in eclipse

* Fixes issue for Forge 31.2.0

Changes the way SoundEvents are constructed as to no longer use depreciated call to super in 31.2.0

* Remove generated files

Some things got past BiomeOPlenty's .gitignore, simply removing them before submitting a PR

* Cleanup

Should resolve style issues in PR

Co-authored-by: D Melton <55304913+DMelton1221@users.noreply.github.com>